### PR TITLE
avoid npm install failed because off github ssh errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "jquery": "^2.1.4",
-    "bootstrap": "git@github.com:twbs/bootstrap.git#v4.0.0-alpha"
+    "bootstrap": "https://github.com/twbs/bootstrap/archive/v4.0.0-alpha.tar.gz"
   }
 }


### PR DESCRIPTION
Avoid npm install failure when github ssh keys are not configured :

npm ERR! git clone --template=/Users/imac/.npm/_git-remotes/_templates --mirror ssh://git@github.com/twbs/bootstrap.git /Users/imac/.npm/_git-remotes/ssh-git-github-com-twbs-bootstrap-git-04c3a07b: Permission denied (publickey).
